### PR TITLE
upgrade to nom 2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ build = "build.rs"
 name = "tls_parser"
 
 [dependencies]
-nom = "1.2.4"
+nom = {version = "^2.0", features=["verbose-errors"] }
 phf = "0.7.16"
 enum_primitive = "0.1.0"
 

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -367,7 +367,7 @@ fn parse_tls_handshake_msg_clientkeyexchange( i:&[u8], len: u64 ) -> IResult<&[u
 
 fn parse_tls_handshake_msg_certificaterequest( i:&[u8] ) -> IResult<&[u8], TlsMessageHandshake> {
     chain!(i,
-        cert_types: length_value!(be_u8,be_u8) ~
+        cert_types: length_count!(be_u8,be_u8) ~
         sig_hash_algs_len: be_u16 ~
         sig_hash_algs: flat_map!(take!(sig_hash_algs_len),many0!(be_u16)) ~
         ca_len: be_u16 ~


### PR DESCRIPTION
Hi!

as a part of the release process for nom 2.0, I selected a few crates to test it with, and make sure everything works correctly.

The behaviour of `length_value!` changed for that release, so now you should use `length_count!` to keep that behaviour.

If you want more information on this release, see the blogpost: https://unhandledexpression.com/2016/11/25/this-year-in-nom-2-0-is-here/ (reddit discussion: https://www.reddit.com/r/rust/comments/5espfm/this_year_in_nom_20_is_here/ )

There are new features that could be of interest for this project :)
