### PR TITLE
add trait ClientHello

### DIFF
--- a/src/dtls.rs
+++ b/src/dtls.rs
@@ -1,12 +1,13 @@
 //! Datagram Transport Layer Security Version 1.2 (RFC 6347)
 
-use crate::tls::*;
-use crate::TlsMessageAlert;
 use nom::bytes::streaming::take;
 use nom::combinator::{complete, cond, map, map_parser, opt, verify};
 use nom::error::{make_error, ErrorKind};
 use nom::multi::{length_data, many1};
 use nom::number::streaming::{be_u16, be_u24, be_u64, be_u8};
+
+use crate::tls::*;
+use crate::TlsMessageAlert;
 
 /// DTLS Plaintext record header
 #[derive(Debug, PartialEq)]
@@ -48,6 +49,32 @@ pub struct DTLSClientHello<'a> {
     /// A list of compression methods supported by client
     pub comp: Vec<TlsCompressionID>,
     pub ext: Option<&'a [u8]>,
+}
+
+impl<'a> ClientHello<'a> for DTLSClientHello<'a> {
+    fn version(&self) -> TlsVersion {
+        self.version
+    }
+
+    fn rand_data(&self) -> &'a [u8] {
+        self.random
+    }
+
+    fn session_id(&self) -> Option<&'a [u8]> {
+        self.session_id
+    }
+
+    fn ciphers(&self) -> &Vec<TlsCipherSuiteID> {
+        &self.ciphers
+    }
+
+    fn comp(&self) -> &Vec<TlsCompressionID> {
+        &self.comp
+    }
+
+    fn ext(&self) -> Option<&'a [u8]> {
+        self.ext
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -216,6 +216,22 @@ impl fmt::LowerHex for TlsCipherSuiteID {
     }
 }
 
+/// A trait that both TLS & DTLS satisfy
+pub trait ClientHello<'a> {
+    /// TLS version of message
+    fn version(&self) -> TlsVersion;
+    fn rand_data(&self) -> &'a [u8];
+    fn session_id(&self) -> Option<&'a [u8]>;
+    /// A list of ciphers supported by client
+    fn ciphers(&self) -> &Vec<TlsCipherSuiteID>;
+    fn cipher_suites(&self) -> Vec<Option<&'static TlsCipherSuite>>{
+        self.ciphers().iter().map(|&x| x.get_ciphersuite()).collect()
+    }
+    /// A list of compression methods supported by client
+    fn comp(&self)-> &Vec<TlsCompressionID>;
+    fn ext(&self)-> Option<&'a [u8]>;
+}
+
 /// TLS Client Hello (from TLS 1.0 to TLS 1.2)
 ///
 /// Some fields are unparsed (for performance reasons), for ex to parse `ext`,
@@ -262,6 +278,32 @@ impl<'a> TlsClientHelloContents<'a> {
 
     pub fn get_ciphers(&self) -> Vec<Option<&'static TlsCipherSuite>> {
         self.ciphers.iter().map(|&x| x.get_ciphersuite()).collect()
+    }
+}
+
+impl<'a> ClientHello<'a> for TlsClientHelloContents<'a> {
+    fn version(&self) -> TlsVersion {
+        self.version
+    }
+
+    fn rand_data(&self) -> &'a [u8] {
+        self.rand_data
+    }
+
+    fn session_id(&self) -> Option<&'a [u8]> {
+        self.session_id
+    }
+
+    fn ciphers(&self) -> &Vec<TlsCipherSuiteID> {
+        &self.ciphers
+    }
+
+    fn comp(&self) -> &Vec<TlsCompressionID> {
+        &self.comp
+    }
+
+    fn ext(&self) -> Option<&'a [u8]> {
+        self.ext
     }
 }
 


### PR DESCRIPTION
Since TLS's client hello and DTLS's client hello have some common fields, add a ClientHello trait could let users to handle these fields by using one same generic function. Sure users could implement this trait by themselves, but it would be nice if it is out of box.