### PR TITLE
Replace enum_primitive with num_enum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ unstable = []
 
 [dependencies]
 cookie-factory = { version="0.3", optional=true }
-enum_primitive = "^0.1"
+num_enum = "0.5.4"
 nom = "7.0"
 nom-derive = "0.10"
 phf = "0.10"

--- a/src/tls_ciphers.rs
+++ b/src/tls_ciphers.rs
@@ -8,14 +8,13 @@
 #![allow(non_camel_case_types)]
 #![allow(clippy::unreadable_literal)]
 
-use enum_primitive::{enum_from_primitive, enum_from_primitive_impl, enum_from_primitive_impl_ty};
+use num_enum::TryFromPrimitive;
 
-enum_from_primitive! {
 /// Key exchange methods
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TlsCipherKx {
-    Null = 0,
+    Null,
     Psk,
     Krb5,
     Srp,
@@ -28,14 +27,12 @@ pub enum TlsCipherKx {
     Eccpwd,
     Tls13,
 }
-}
 
-enum_from_primitive! {
 /// Authentication methods
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TlsCipherAu {
-    Null = 0,
+    Null,
     Psk,
     Krb5,
     Srp,
@@ -48,11 +45,9 @@ pub enum TlsCipherAu {
     Eccpwd,
     Tls13,
 }
-}
 
-enum_from_primitive! {
 /// Encryption methods
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TlsCipherEnc {
     Null,
@@ -68,11 +63,9 @@ pub enum TlsCipherEnc {
     Chacha20_Poly1305,
     Sm4,
 }
-}
 
-enum_from_primitive! {
 /// Encryption modes
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, TryFromPrimitive)]
 #[repr(u8)]
 pub enum TlsCipherEncMode {
     Null,
@@ -80,9 +73,7 @@ pub enum TlsCipherEncMode {
     Ccm,
     Gcm,
 }
-}
 
-enum_from_primitive! {
 /// Message Authentication Code (MAC) methods
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
@@ -93,7 +84,6 @@ pub enum TlsCipherMac {
     HmacSha256,
     HmacSha384,
     Aead,
-}
 }
 
 /// TLS Ciphersuite


### PR DESCRIPTION
enum_primitive is very old and unmaintained, it has the following issues:
* doesnt make use of #derive
* pulls in an outdated release of num_traits.
* Implements a custom trait in num_traits instead of implementing https://doc.rust-lang.org/std/convert/trait.TryFrom.html

Alternatively we could just remove the enum_primitive functionality entirely, but I assume tls-parser wants to maintain that functionality.

I removed the `= 0` from some variants as that is already done by default as per https://doc.rust-lang.org/reference/items/enumerations.html#custom-discriminant-values-for-fieldless-enumerations