### PR TITLE
Update extract-iana-ciphers script to use https

### DIFF
--- a/scripts/extract-iana-ciphers.py
+++ b/scripts/extract-iana-ciphers.py
@@ -2,7 +2,7 @@
 
 import urllib2
 from BeautifulSoup import BeautifulSoup, ResultSet
-file = urllib2.urlopen('http://www.iana.org/assignments/tls-parameters/tls-parameters.xml')
+file = urllib2.urlopen('https://www.iana.org/assignments/tls-parameters/tls-parameters.xml')
 data = file.read()
 with open('tls-parameters.xml', 'wb') as myFile:
     myFile.write(data)


### PR DESCRIPTION
urllib supports https & http connections should be avoided where https is available.

This will have a better end user experience for customers who have static analyses running against their code base.

www.iana.org supports https connections.