### PR TITLE
ci: update cargo-check-external-types toolchain

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-02-07
+          toolchain: nightly-2024-05-01
           # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
       - run: cargo install cargo-check-external-types
       - run: cargo check-external-types


### PR DESCRIPTION
👋 As promised, when cargo-check-external-types makes an update I'm opening PRs to fix the builds :-) The upstream project cut a 0.1.12 release that now pins Rust nightly-2024-05-01. This commit updates CI to match.